### PR TITLE
Adding simple broker test system configs

### DIFF
--- a/testcases/README.dm
+++ b/testcases/README.dm
@@ -2,6 +2,16 @@
 
 This folder contains different aspects for the _System under test_ and their various Configurations
 
+## Channel Configurations
+
+Setup using the `Channel` implementations and `Subscription` API to deliver their events.
 
 * `InMemoryChannel` and a single Subscription ([here](./imc-test-config))
 * Default `KafkaMemoryChannel` and a single Subscription ([here](./kc-test-config-simple))
+
+## Broker Configurations
+
+Setup using the default `Broker` implementation, backed with by different channel implementations and using the `Trigger` API to deliver their events.
+
+* Broker backed by `InMemoryChannel` ([here](./broker-imc-config))
+* Broker backed by `KafkaMemoryChannel` ([here](./broker-kc-config))

--- a/testcases/broker-imc-config/000-hyperfoil-cluster.yaml
+++ b/testcases/broker-imc-config/000-hyperfoil-cluster.yaml
@@ -1,0 +1,20 @@
+# TODO: HF operator should create this service automatically, soon...
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: hyperfoil-cluster
+  name: hyperfoil-cluster
+  namespace: hyperfoil
+spec:
+  clusterIP: None
+  ports:
+  - name: 7800-7800
+    port: 7800
+    protocol: TCP
+    targetPort: 7800
+  selector:
+    app: hyperfoil
+    role: controller
+  sessionAffinity: None
+  type: ClusterIP

--- a/testcases/broker-imc-config/100-broker.yaml
+++ b/testcases/broker-imc-config/100-broker.yaml
@@ -1,0 +1,4 @@
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  name: my-imc-broker

--- a/testcases/broker-imc-config/100-pod.yaml
+++ b/testcases/broker-imc-config/100-pod.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: receiver
+spec:
+  selector:
+    app: receiver
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: receiver
+      name: http
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: receiver
+  labels:
+    app: receiver
+spec:
+  containers:
+  - name: receiver
+    image: quay.io/rvansa/eventing-hyperfoil-benchmark-vertx-receiver
+    imagePullPolicy: Always
+    ports:
+    - containerPort: 8080
+      protocol: TCP
+      name: receiver
+    env:
+    - name: IO_HYPERFOIL_CONTROLLER_CLUSTER_IP
+      value: hyperfoil-cluster.hyperfoil.svc.cluster.local
+    - name: IO_HYPERFOIL_CONTROLLER_CLUSTER_PORT
+      value: "7800"

--- a/testcases/broker-imc-config/200-trigger.yaml
+++ b/testcases/broker-imc-config/200-trigger.yaml
@@ -1,0 +1,11 @@
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: trigger-all-events-for-imc-broker
+spec:
+  broker: my-imc-broker 
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: receiver

--- a/testcases/broker-imc-config/README.md
+++ b/testcases/broker-imc-config/README.md
@@ -8,4 +8,4 @@ Broker uses a default InMemory channel, no extra configurations like `retry`.
 
 ## Trigger
 
-No filtering on event types or other metadata, all wevents are routed to a `v1` kubernetes `Service`, which represents the Hyperfoil receiver.
+No filtering on event types or other metadata, all events are routed to a `v1` kubernetes `Service`, which represents the Hyperfoil receiver.

--- a/testcases/broker-imc-config/README.md
+++ b/testcases/broker-imc-config/README.md
@@ -1,0 +1,11 @@
+#InMemoryChannel based Broker Performance test
+
+Configuration for a testing the `Broker`, backed by a `InMemoryChannel`.
+
+## InMemory Channel based Broker
+
+Broker uses a default InMemory channel, no extra configurations like `retry`.
+
+## Trigger
+
+No filtering on event types or other metadata, all wevents are routed to a `v1` kubernetes `Service`, which represents the Hyperfoil receiver.

--- a/testcases/broker-kc-config/000-hyperfoil-cluster.yaml
+++ b/testcases/broker-kc-config/000-hyperfoil-cluster.yaml
@@ -1,0 +1,20 @@
+# TODO: HF operator should create this service automatically, soon...
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: hyperfoil-cluster
+  name: hyperfoil-cluster
+  namespace: hyperfoil
+spec:
+  clusterIP: None
+  ports:
+  - name: 7800-7800
+    port: 7800
+    protocol: TCP
+    targetPort: 7800
+  selector:
+    app: hyperfoil
+    role: controller
+  sessionAffinity: None
+  type: ClusterIP

--- a/testcases/broker-kc-config/100-broker.yaml
+++ b/testcases/broker-kc-config/100-broker.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-kafkachannel-broker
+data:
+  channelTemplateSpec: |-
+    apiVersion: messaging.knative.dev/v1beta1
+    kind: KafkaChannel
+    spec:
+        numPartitions: 1
+        replicationFactor: 1
+---
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  name: my-kafkachannel-broker
+spec:
+  config:
+    apiVersion: v1
+    kind: ConfigMap
+    name: my-kafkachannel-broker

--- a/testcases/broker-kc-config/100-pod.yaml
+++ b/testcases/broker-kc-config/100-pod.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: receiver
+spec:
+  selector:
+    app: receiver
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: receiver
+      name: http
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: receiver
+  labels:
+    app: receiver
+spec:
+  containers:
+  - name: receiver
+    image: quay.io/rvansa/eventing-hyperfoil-benchmark-vertx-receiver
+    imagePullPolicy: Always
+    ports:
+    - containerPort: 8080
+      protocol: TCP
+      name: receiver
+    env:
+    - name: IO_HYPERFOIL_CONTROLLER_CLUSTER_IP
+      value: hyperfoil-cluster.hyperfoil.svc.cluster.local
+    - name: IO_HYPERFOIL_CONTROLLER_CLUSTER_PORT
+      value: "7800"

--- a/testcases/broker-kc-config/200-trigger.yaml
+++ b/testcases/broker-kc-config/200-trigger.yaml
@@ -1,0 +1,11 @@
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: trigger-all-events-for-kc-broker
+spec:
+  broker: my-kafkachannel-broker 
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: receiver

--- a/testcases/broker-kc-config/README.md
+++ b/testcases/broker-kc-config/README.md
@@ -8,4 +8,4 @@ Broker uses a default Kafka channel, no extra configurations like `numPartitions
 
 ## Trigger
 
-No filtering on event types or other metadata, all wevents are routed to a `v1` kubernetes `Service`, which represents the Hyperfoil receiver.
+No filtering on event types or other metadata, all events are routed to a `v1` kubernetes `Service`, which represents the Hyperfoil receiver.

--- a/testcases/broker-kc-config/README.md
+++ b/testcases/broker-kc-config/README.md
@@ -1,0 +1,11 @@
+#KafkaChannel based Broker Performance test
+
+Configuration for a testing the `Broker`, backed by a `KafkaChannel`.
+
+## Kafka Channel based Broker
+
+Broker uses a default Kafka channel, no extra configurations like `numPartitions`, `replicationFactor` or `retry`.
+
+## Trigger
+
+No filtering on event types or other metadata, all wevents are routed to a `v1` kubernetes `Service`, which represents the Hyperfoil receiver.


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

more tests, for brokers (based on `IMC` and `KafkaChannel`).

/assign @slinkydeveloper 