### PR TITLE
Adding OWNERS and ALIASES for openshift-eventing repos

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,7 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+approvers:
+- eventing-approvers
+
+reviewers:
+- eventing-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,18 @@
+aliases:
+  eventing-approvers:
+  - alanfx
+  - aliok
+  - devguyio
+  - jcrossley3
+  - lberk
+  - markusthoemmes
+  - matzew
+  - mgencur
+  - pierDipi
+  - skonto
+  eventing-reviewers:
+  - aliok
+  - devguyio
+  - lberk
+  - matzew
+  - pierDipi


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>