### PR TITLE
Adding annotations to be clear that the  is the MT Channel Based Broker

### DIFF
--- a/testcases/broker/eventing-broker/broker-imc-config/100-broker.yaml
+++ b/testcases/broker/eventing-broker/broker-imc-config/100-broker.yaml
@@ -1,4 +1,6 @@
 apiVersion: eventing.knative.dev/v1
 kind: Broker
 metadata:
+  annotations:
+    eventing.knative.dev/broker.class: MTChannelBasedBroker
   name: my-imc-broker

--- a/testcases/broker/eventing-broker/broker-kc-advanced-config/100-broker.yaml
+++ b/testcases/broker/eventing-broker/broker-kc-advanced-config/100-broker.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  annotations:
+    eventing.knative.dev/broker.class: MTChannelBasedBroker
   name: my-kafkachannel-advanced-broker
 data:
   channelTemplateSpec: |-

--- a/testcases/broker/eventing-broker/broker-kc-config/100-broker.yaml
+++ b/testcases/broker/eventing-broker/broker-kc-config/100-broker.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  annotations:
+    eventing.knative.dev/broker.class: MTChannelBasedBroker
   name: my-kafkachannel-broker
 data:
   channelTemplateSpec: |-


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>


Adding annotations to be clear that the  is the MT Channel Based Broker, and we do not conflict with any given default broker, on the SUT

/assign @aliok 
/assign @pierDipi 