### PR TITLE
Use wget instead of curl to update nightlies

### DIFF
--- a/bin/update-nightlies.sh
+++ b/bin/update-nightlies.sh
@@ -3,12 +3,12 @@
 rm -rf installation/manifests/nightly/eventing
 rm -rf installation/manifests/nightly/eventing-kafka-broker
 
-curl --create-dirs -O --output-dir installation/manifests/nightly/eventing-kafka-broker https://storage.googleapis.com/knative-nightly/eventing-kafka-broker/latest/eventing-kafka-broker.yaml
-curl --create-dirs -O --output-dir installation/manifests/nightly/eventing-kafka-broker https://storage.googleapis.com/knative-nightly/eventing-kafka-broker/latest/eventing-kafka-channel.yaml
-curl --create-dirs -O --output-dir installation/manifests/nightly/eventing-kafka-broker https://storage.googleapis.com/knative-nightly/eventing-kafka-broker/latest/eventing-kafka-controller.yaml
-curl --create-dirs -O --output-dir installation/manifests/nightly/eventing-kafka-broker https://storage.googleapis.com/knative-nightly/eventing-kafka-broker/latest/eventing-kafka-source.yaml
-curl --create-dirs -O --output-dir installation/manifests/nightly/eventing-kafka-broker https://storage.googleapis.com/knative-nightly/eventing-kafka-broker/latest/eventing-kafka-sink.yaml
-
-curl --create-dirs -O --output-dir installation/manifests/nightly/eventing https://storage.googleapis.com/knative-nightly/eventing/latest/eventing-core.yaml
-curl --create-dirs -O --output-dir installation/manifests/nightly/eventing https://storage.googleapis.com/knative-nightly/eventing/latest/mt-channel-broker.yaml
-curl --create-dirs -O --output-dir installation/manifests/nightly/eventing https://storage.googleapis.com/knative-nightly/eventing/latest/eventing-post-install.yaml
+wget -P installation/manifests/nightly/eventing-kafka-broker https://storage.googleapis.com/knative-nightly/eventing-kafka-broker/latest/eventing-kafka-broker.yaml
+wget -P installation/manifests/nightly/eventing-kafka-broker https://storage.googleapis.com/knative-nightly/eventing-kafka-broker/latest/eventing-kafka-channel.yaml
+wget -P installation/manifests/nightly/eventing-kafka-broker https://storage.googleapis.com/knative-nightly/eventing-kafka-broker/latest/eventing-kafka-controller.yaml
+wget -P installation/manifests/nightly/eventing-kafka-broker https://storage.googleapis.com/knative-nightly/eventing-kafka-broker/latest/eventing-kafka-source.yaml
+wget -P installation/manifests/nightly/eventing-kafka-broker https://storage.googleapis.com/knative-nightly/eventing-kafka-broker/latest/eventing-kafka-sink.yaml
+wget -P
+wget -P installation/manifests/nightly/eventing https://storage.googleapis.com/knative-nightly/eventing/latest/eventing-core.yaml
+wget -P installation/manifests/nightly/eventing https://storage.googleapis.com/knative-nightly/eventing/latest/mt-channel-broker.yaml
+wget -P installation/manifests/nightly/eventing https://storage.googleapis.com/knative-nightly/eventing/latest/eventing-post-install.yaml


### PR DESCRIPTION
`curl` version in latest `Ubunutu` doesn't support
`--output-dir`, so use `wget` instead.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>