### PR TITLE
Migrate Eventing to v1beta1

### DIFF
--- a/installation/manifests/product/100-knative-eventing.yaml
+++ b/installation/manifests/product/100-knative-eventing.yaml
@@ -1,4 +1,4 @@
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeEventing
 metadata:
   name: knative-eventing


### PR DESCRIPTION
- See latest failure: https://github.com/openshift/release/pull/45546#issuecomment-1805809184 and https://github.com/openshift/release/pull/45546#issuecomment-1805661453.
- We have long moved to v1beta1 crds